### PR TITLE
Skip Bootstrapping if content seems compressed

### DIFF
--- a/lib/Plack/Middleware/Bootstrap.pm
+++ b/lib/Plack/Middleware/Bootstrap.pm
@@ -22,6 +22,7 @@ sub call {
 
             my $plack_res = Plack::Response->new(@$res);
             return unless $plack_res->content_type =~ /\Atext\/html/;
+            return if $plack_res->content_encoding;
 
             my $content;
             Plack::Util::foreach($res->[2] || [], sub { $content .= $_[0] });

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -145,4 +145,24 @@ subtest 'Content-Length of filtered content is removed' => sub {
     };
 };
 
+subtest 'No compress when Content-Encoding specified' => sub {
+    note 'Middleware::Bootstrap cannot handle compressed content, so skip if content seems compressed.';
+    my $content = "<head>Hello</head><body>World!</body>";
+    my $app = builder {
+        enable 'Bootstrap';
+        sub {
+            # actually content is not compressed ;D
+            return [ 200, [ 'Content-Type' => 'text/html; charset=utf-8', 'Content-Encoding' => 'gzip', ], [ $content ] ];
+        }
+    };
+
+    test_psgi $app => sub {
+        my $server = shift;
+
+        my $res = $server->(GET "http://localhost/");
+        is $res->code, 200;
+        is $res->content, $content;
+    };
+};
+
 done_testing;


### PR DESCRIPTION
Middleware::Bootstrap cannot handle compressed content properly.
So, at least, We can prevent broken responses by skipping when "Content-Encoding" header detected.